### PR TITLE
This pull complements a change for solving #1265

### DIFF
--- a/WINDOWS/WINDOW.C
+++ b/WINDOWS/WINDOW.C
@@ -726,7 +726,10 @@ int WINAPI WinMain(HINSTANCE inst, HINSTANCE prev, LPSTR cmdline, int show)
 	if (conf_get_int(conf, CONF_sunken_edge))
 	    exwinmode |= WS_EX_CLIENTEDGE;
 #ifdef PUTTYNG
-	winmode &= ~(WS_POPUPWINDOW);
+	if (hwnd_parent != 0)
+	{
+		winmode &= ~(WS_POPUPWINDOW);
+	}
 #endif // PUTTYNG
 	hwnd = CreateWindowExW(exwinmode, uappname, uappname,
                                winmode, CW_USEDEFAULT, CW_USEDEFAULT,

--- a/WINDOWS/WINDOW.C
+++ b/WINDOWS/WINDOW.C
@@ -725,6 +725,9 @@ int WINAPI WinMain(HINSTANCE inst, HINSTANCE prev, LPSTR cmdline, int show)
 	    exwinmode |= WS_EX_TOPMOST;
 	if (conf_get_int(conf, CONF_sunken_edge))
 	    exwinmode |= WS_EX_CLIENTEDGE;
+#ifdef PUTTYNG
+	winmode &= ~(WS_POPUPWINDOW);
+#endif // PUTTYNG
 	hwnd = CreateWindowExW(exwinmode, uappname, uappname,
                                winmode, CW_USEDEFAULT, CW_USEDEFAULT,
                                guess_width, guess_height,
@@ -734,6 +737,7 @@ int WINAPI WinMain(HINSTANCE inst, HINSTANCE prev, LPSTR cmdline, int show)
 	{
 	    SetParent(hwnd, (HWND)hwnd_parent); // Focus doesn't work correctly if this is passed into CreateWindow, so set it separately.
 	    hwnd_parent_main = GetAncestor((HWND)hwnd_parent, GA_ROOTOWNER); // the top level ancestor of hwnd_parent
+		SetWindowLong(hwnd, GWL_STYLE, 0);
 	}
 #endif // PUTTYNG
         sfree(uappname);


### PR DESCRIPTION
This creates a window without borders or title in puttyng mode, as such, no corrections needs to be made when is integrated inside a form in DPS