### PR TITLE
-auth-plugin parameter

### DIFF
--- a/PuTTYNG.ps1
+++ b/PuTTYNG.ps1
@@ -98,6 +98,13 @@ if (Test-Path -LiteralPath $workFolder) {
 		    hwnd_parent = atoi(value);
 		    return 2;
 	    }
+        if (!strcmp(p, "-auth-plugin") || !strcmp(p, "-auth_plugin")) {
+            RETURN(2);
+            UNAVAILABLE_IN(TOOLTYPE_NONNETWORK);
+            SAVEABLE(0);
+            conf_set_str(conf, CONF_auth_plugin, value);
+            return 2;
+        }
     #endif
 
     if (!strcmp(p, "-load")) {'
@@ -211,6 +218,10 @@ if (Test-Path -LiteralPath $workFolder) {
     # run cmake
     Write-host "Build has been started"
     try { 
+                # Ensure MSVC and CMake see the PUTTYNG define
+        $env:CL = "/DPUTTYNG " + $env:CL
+        $env:CMAKE_C_FLAGS = "/DPUTTYNG"
+        $env:CMAKE_CXX_FLAGS = "/DPUTTYNG"
           Start-Process -FilePath "make22.cmd" -Wait 
      }
     catch {


### PR DESCRIPTION
## Description
Added a new parameter  for authenticator plugin the original putty misses

## Motivation and Context
I need to start putty with the plugin path as a parameter

## How Has This Been Tested?
I used it with mRemoteNG

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Changed feature (non-breaking change which changes functionality)
- [ ] Changed feature (**breaking** change which changes functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Updated translation

## Checklist:
<!--- Go over all the following points. All of them must apply to your pull request. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] All Tests within VisualStudio are passing
- [ ] This pull request does not target the master branch.
- [ ] I have updated the changelog file accordingly, if necessary.
- [ ] I have updated the documentation accordingly, if necessary.
