### PR TITLE
fix: set InternalName to 'PuTTYNG' for mRemoteNG detection

### DIFF
--- a/PuTTYNG.ps1
+++ b/PuTTYNG.ps1
@@ -133,6 +133,16 @@ if (Test-Path -LiteralPath $workFolder) {
     (Get-Content $workFile).Replace('-Unidentified-Local-Build', '-Release-mRemoteNG-Build') | Set-Content $workFile
     (Get-Content $workFile).Replace('0,0,0,0', $setNewVersion) | Set-Content $workFile
     Write-Host "Code block replaced successfully in '$workFile'."
+
+    # Fix InternalName: PuTTY uses APPNAME macro for InternalName in the .rc resource.
+    # Patch version.h to define a custom APPNAME so the compiled exe reports "PuTTYNG"
+    # instead of "PuTTY". This is needed for mRemoteNG's PuttyTypeDetector to identify
+    # the embedded PuTTYNG and enable -hwndparent (embedded window mode).
+    $versionContent = Get-Content $workFile -Raw
+    if ($versionContent -notmatch 'PUTTYNG_APPNAME') {
+        Add-Content $workFile "`n/* Override InternalName for mRemoteNG detection */`n#define APPNAME `"PuTTYNG`"`n"
+        Write-Host "Added APPNAME override to '$workFile'."
+    }
     #===================================================================================================
 
     #Add mRemoteNG required changes


### PR DESCRIPTION
## Problem

PuTTYNG v0.83.0.1.x64 reports `InternalName = "PuTTY"` instead of `"PuTTYNG"` in the Windows version resource.

```
FileVersion:      Release 0.83 mRemoteNG (without embedded help)
InternalName:     PuTTY          ← should be PuTTYNG
ProductVersion:   Release 0.83 mRemoteNG
```

## Impact

mRemoteNG's `PuttyTypeDetector.IsPuttyNg()` checks `InternalName.Contains("PuTTYNG")` to enable PuTTYNG-specific features:
- **`-hwndparent`** — embeds PuTTYNG inside the mRemoteNG tab (the primary reason PuTTYNG exists)
- PuTTYNG-specific window search logic
- Startup behavior (PuTTYNG doesn't start minimized, unlike classic PuTTY)

With `InternalName = "PuTTY"`, PuTTYNG is misidentified as standard PuTTY, and embedded mode doesn't activate properly.

## Root Cause

`PuTTYNG.ps1` modifies `version.h` to set `ProductVersion` to `"Release X.XX mRemoteNG"` but doesn't override the `APPNAME` macro that PuTTY's resource files use for `InternalName`. Since PuTTY's default APPNAME is `"PuTTY"`, the compiled exe inherits that value.

## Fix

Append an `APPNAME` define override to `version.h` after the existing version modifications:
```c
#define APPNAME "PuTTYNG"
```

This ensures the compiled Windows resource reports `InternalName = "PuTTYNG"`.

## Workaround (already applied in mRemoteNG fork)

We've added a fallback detection in `PuttyTypeDetector` that also checks `ProductVersion.Contains("mRemoteNG")`, but the proper fix belongs here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)